### PR TITLE
[fix] admin is be a correct user in yunohost

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ yunohost:
         domain: example.com
   # The list of users.
   users:
-    - name: admin
+    - name: user1
       pass: p@ssw0rd
-      firstname: admin
-      lastname: admin
-      mail: admin@example.com
+      firstname: Jane
+      lastname: Doe
+      mail: jane.doe@example.com
 ```
 
 Dependencies


### PR DESCRIPTION
Hi,
I suggest this change in your documentation beacause "admin" is a specific user on a yunohost instance.

There shouldn't be yunohost user call admin, could be confused with the "admin" of the instance