### PR TITLE
Run diagnosis before installing certificates

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,9 @@
   include: domains.yml
   when: yunohost.extra_domains
 
+- name: Run diagnosis # Required to install certificates
+  shell: yunohost diagnosis run
+
 - name: Install certificates
   shell: yunohost domain cert-install
   changed_when: False


### PR DESCRIPTION
Solves #4 

I initially thought about [parsing the output of the command](https://github.com/rthouvenin/ansible-yunohost/commit/1690eef1685fbd5356ca705c9c15abf7c17231a9) so that ansible correctly reports on changed vs ok. But finally I think it's better without because:

 - Yunohost localises user messages, so if someone has set their server on a non-English locale the check will not be correct
 - If the diagnosis is run manually but not fully, the cache may be valid for only a part of the diagnosis. In this case the check will detect no change even though there will be a change
 - The diagnosis is rarely run before its cache invalidates, so in practice it is a good approximation to say that the task always caused a change