### PR TITLE
Remove admin-password option from yunohost commands

### DIFF
--- a/tasks/domains.yml
+++ b/tasks/domains.yml
@@ -8,6 +8,6 @@
   set_fact: yunohost_installed_domains="{{ yunohost_installed_domains_raw.stdout | from_json }}"
 
 - name: Create domains
-  shell: yunohost domain add {{ item }} --admin-password {{ yunohost.password }}
+  shell: yunohost domain add {{ item }}
   with_items: "{{ yunohost.extra_domains }}"
   when: item not in yunohost_installed_domains.domains

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -9,7 +9,7 @@
 
 - name: Create missing users
   shell: |
-    yunohost user create {{ item.name }} --admin-password {{ yunohost.password }} \
+    yunohost user create {{ item.name }} \
     -f {{ item.firstname }} \
     -l {{ item.lastname }} \
     -m {{ item.mail }} \


### PR DESCRIPTION
I had not noticed the `--admin-password` option until some ansible tasks started to fail, so I guess the option got removed in a recent release of yunohost. I never had to use it when running the command "manually" on servers, and the command always asked me to run it as root whenever I didn't, so I think the option was not needed even in earlier versions and I simply removed it.

But let me know if that should be kept (configurable) for some older versions that may still be used.